### PR TITLE
feat: Add ldflags support for Go build optimization

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -84,7 +84,7 @@ func (bc *BuildCommand) RunBuildWithResults() ([]models.ArchiveResult, error) {
 
 	fmt.Printf("Building %s version %s\n", buildInfo.ModuleName, buildInfo.Version)
 
-	buildResults, err := bc.builderService.BuildTargets(buildInfo, cfg.Build.Targets)
+	buildResults, err := bc.builderService.BuildTargets(buildInfo, cfg.Build)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build targets: %w", err)
 	}

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -84,7 +84,7 @@ func TestBuildCommand_FormulaGeneration(t *testing.T) {
 			mockConfigService.EXPECT().LoadConfig().Return(config, nil)
 			mockVersionService.EXPECT().GetBuildInfo().Return(buildInfo, nil)
 			mockFS.EXPECT().EnsureDistDir(false).Return(nil)
-			mockBuilderService.EXPECT().BuildTargets(buildInfo, config.Build.Targets).Return(buildResults, nil)
+			mockBuilderService.EXPECT().BuildTargets(buildInfo, config.Build).Return(buildResults, nil)
 			mockArchiverService.EXPECT().CreateArchives(buildInfo, buildResults).Return(archiveResults, nil)
 			mockFS.EXPECT().Remove("dist/gorocket_darwin_amd64").Return(nil)
 
@@ -164,7 +164,7 @@ func TestBuildCommand_FullWorkflow(t *testing.T) {
 	mockConfigService.EXPECT().LoadConfig().Return(config, nil)
 	mockVersionService.EXPECT().GetBuildInfo().Return(buildInfo, nil)
 	mockFS.EXPECT().EnsureDistDir(true).Return(nil)
-	mockBuilderService.EXPECT().BuildTargets(buildInfo, config.Build.Targets).Return(buildResults, nil)
+	mockBuilderService.EXPECT().BuildTargets(buildInfo, config.Build).Return(buildResults, nil)
 	mockArchiverService.EXPECT().CreateArchives(buildInfo, buildResults).Return(archiveResults, nil)
 
 	// Expect removal of binary files

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -6,6 +6,7 @@ type Config struct {
 }
 
 type BuildConfig struct {
+	LdFlags string   `yaml:"ldflags,omitempty"`
 	Targets []Target `yaml:"targets"`
 }
 

--- a/internal/providers/config_default.yaml
+++ b/internal/providers/config_default.yaml
@@ -1,4 +1,5 @@
 build:
+  # ldflags: "-s -w"  # Optional: linker flags for binary optimization
   targets:
     - os: linux
       arch: [amd64, arm64]

--- a/internal/providers/mocks/mock_CommandProvider.go
+++ b/internal/providers/mocks/mock_CommandProvider.go
@@ -36,8 +36,8 @@ func (_m *MockCommandProvider) EXPECT() *MockCommandProvider_Expecter {
 }
 
 // BuildBinary provides a mock function for the type MockCommandProvider
-func (_mock *MockCommandProvider) BuildBinary(moduleName string, version string, osName string, arch string) (string, error) {
-	ret := _mock.Called(moduleName, version, osName, arch)
+func (_mock *MockCommandProvider) BuildBinary(moduleName string, version string, osName string, arch string, ldflags string) (string, error) {
+	ret := _mock.Called(moduleName, version, osName, arch, ldflags)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildBinary")
@@ -45,16 +45,16 @@ func (_mock *MockCommandProvider) BuildBinary(moduleName string, version string,
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) (string, error)); ok {
-		return returnFunc(moduleName, version, osName, arch)
+	if returnFunc, ok := ret.Get(0).(func(string, string, string, string, string) (string, error)); ok {
+		return returnFunc(moduleName, version, osName, arch, ldflags)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) string); ok {
-		r0 = returnFunc(moduleName, version, osName, arch)
+	if returnFunc, ok := ret.Get(0).(func(string, string, string, string, string) string); ok {
+		r0 = returnFunc(moduleName, version, osName, arch, ldflags)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = returnFunc(moduleName, version, osName, arch)
+	if returnFunc, ok := ret.Get(1).(func(string, string, string, string, string) error); ok {
+		r1 = returnFunc(moduleName, version, osName, arch, ldflags)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -71,11 +71,12 @@ type MockCommandProvider_BuildBinary_Call struct {
 //   - version string
 //   - osName string
 //   - arch string
-func (_e *MockCommandProvider_Expecter) BuildBinary(moduleName interface{}, version interface{}, osName interface{}, arch interface{}) *MockCommandProvider_BuildBinary_Call {
-	return &MockCommandProvider_BuildBinary_Call{Call: _e.mock.On("BuildBinary", moduleName, version, osName, arch)}
+//   - ldflags string
+func (_e *MockCommandProvider_Expecter) BuildBinary(moduleName interface{}, version interface{}, osName interface{}, arch interface{}, ldflags interface{}) *MockCommandProvider_BuildBinary_Call {
+	return &MockCommandProvider_BuildBinary_Call{Call: _e.mock.On("BuildBinary", moduleName, version, osName, arch, ldflags)}
 }
 
-func (_c *MockCommandProvider_BuildBinary_Call) Run(run func(moduleName string, version string, osName string, arch string)) *MockCommandProvider_BuildBinary_Call {
+func (_c *MockCommandProvider_BuildBinary_Call) Run(run func(moduleName string, version string, osName string, arch string, ldflags string)) *MockCommandProvider_BuildBinary_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -93,11 +94,16 @@ func (_c *MockCommandProvider_BuildBinary_Call) Run(run func(moduleName string, 
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -108,7 +114,7 @@ func (_c *MockCommandProvider_BuildBinary_Call) Return(s string, err error) *Moc
 	return _c
 }
 
-func (_c *MockCommandProvider_BuildBinary_Call) RunAndReturn(run func(moduleName string, version string, osName string, arch string) (string, error)) *MockCommandProvider_BuildBinary_Call {
+func (_c *MockCommandProvider_BuildBinary_Call) RunAndReturn(run func(moduleName string, version string, osName string, arch string, ldflags string) (string, error)) *MockCommandProvider_BuildBinary_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/services/builder.go
+++ b/internal/services/builder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type BuilderService interface {
-	BuildTargets(buildInfo *models.BuildInfo, targets []models.Target) ([]models.BuildResult, error)
+	BuildTargets(buildInfo *models.BuildInfo, buildConfig models.BuildConfig) ([]models.BuildResult, error)
 }
 
 type builderService struct {
@@ -22,18 +22,18 @@ func NewBuilderService(commandProvider providers.CommandProvider, fileSystemProv
 	}
 }
 
-func (b *builderService) BuildTargets(buildInfo *models.BuildInfo, targets []models.Target) ([]models.BuildResult, error) {
+func (b *builderService) BuildTargets(buildInfo *models.BuildInfo, buildConfig models.BuildConfig) ([]models.BuildResult, error) {
 	var results []models.BuildResult
 	var errGroup *multierror.Error
 
-	for _, target := range targets {
+	for _, target := range buildConfig.Targets {
 		for _, arch := range target.Arch {
 			buildTarget := models.BuildTarget{
 				OS:   target.OS,
 				Arch: arch,
 			}
 
-			binaryPath, err := b.commandProvider.BuildBinary(buildInfo.ModuleName, buildInfo.Version, target.OS, arch)
+			binaryPath, err := b.commandProvider.BuildBinary(buildInfo.ModuleName, buildInfo.Version, target.OS, arch, buildConfig.LdFlags)
 			if err != nil {
 				errGroup = multierror.Append(errGroup, err)
 				continue

--- a/internal/services/mocks/mock_BuilderService.go
+++ b/internal/services/mocks/mock_BuilderService.go
@@ -37,8 +37,8 @@ func (_m *MockBuilderService) EXPECT() *MockBuilderService_Expecter {
 }
 
 // BuildTargets provides a mock function for the type MockBuilderService
-func (_mock *MockBuilderService) BuildTargets(buildInfo *models.BuildInfo, targets []models.Target) ([]models.BuildResult, error) {
-	ret := _mock.Called(buildInfo, targets)
+func (_mock *MockBuilderService) BuildTargets(buildInfo *models.BuildInfo, buildConfig models.BuildConfig) ([]models.BuildResult, error) {
+	ret := _mock.Called(buildInfo, buildConfig)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildTargets")
@@ -46,18 +46,18 @@ func (_mock *MockBuilderService) BuildTargets(buildInfo *models.BuildInfo, targe
 
 	var r0 []models.BuildResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*models.BuildInfo, []models.Target) ([]models.BuildResult, error)); ok {
-		return returnFunc(buildInfo, targets)
+	if returnFunc, ok := ret.Get(0).(func(*models.BuildInfo, models.BuildConfig) ([]models.BuildResult, error)); ok {
+		return returnFunc(buildInfo, buildConfig)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*models.BuildInfo, []models.Target) []models.BuildResult); ok {
-		r0 = returnFunc(buildInfo, targets)
+	if returnFunc, ok := ret.Get(0).(func(*models.BuildInfo, models.BuildConfig) []models.BuildResult); ok {
+		r0 = returnFunc(buildInfo, buildConfig)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.BuildResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*models.BuildInfo, []models.Target) error); ok {
-		r1 = returnFunc(buildInfo, targets)
+	if returnFunc, ok := ret.Get(1).(func(*models.BuildInfo, models.BuildConfig) error); ok {
+		r1 = returnFunc(buildInfo, buildConfig)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -71,20 +71,20 @@ type MockBuilderService_BuildTargets_Call struct {
 
 // BuildTargets is a helper method to define mock.On call
 //   - buildInfo *models.BuildInfo
-//   - targets []models.Target
-func (_e *MockBuilderService_Expecter) BuildTargets(buildInfo interface{}, targets interface{}) *MockBuilderService_BuildTargets_Call {
-	return &MockBuilderService_BuildTargets_Call{Call: _e.mock.On("BuildTargets", buildInfo, targets)}
+//   - buildConfig models.BuildConfig
+func (_e *MockBuilderService_Expecter) BuildTargets(buildInfo interface{}, buildConfig interface{}) *MockBuilderService_BuildTargets_Call {
+	return &MockBuilderService_BuildTargets_Call{Call: _e.mock.On("BuildTargets", buildInfo, buildConfig)}
 }
 
-func (_c *MockBuilderService_BuildTargets_Call) Run(run func(buildInfo *models.BuildInfo, targets []models.Target)) *MockBuilderService_BuildTargets_Call {
+func (_c *MockBuilderService_BuildTargets_Call) Run(run func(buildInfo *models.BuildInfo, buildConfig models.BuildConfig)) *MockBuilderService_BuildTargets_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 *models.BuildInfo
 		if args[0] != nil {
 			arg0 = args[0].(*models.BuildInfo)
 		}
-		var arg1 []models.Target
+		var arg1 models.BuildConfig
 		if args[1] != nil {
-			arg1 = args[1].([]models.Target)
+			arg1 = args[1].(models.BuildConfig)
 		}
 		run(
 			arg0,
@@ -99,7 +99,7 @@ func (_c *MockBuilderService_BuildTargets_Call) Return(buildResults []models.Bui
 	return _c
 }
 
-func (_c *MockBuilderService_BuildTargets_Call) RunAndReturn(run func(buildInfo *models.BuildInfo, targets []models.Target) ([]models.BuildResult, error)) *MockBuilderService_BuildTargets_Call {
+func (_c *MockBuilderService_BuildTargets_Call) RunAndReturn(run func(buildInfo *models.BuildInfo, buildConfig models.BuildConfig) ([]models.BuildResult, error)) *MockBuilderService_BuildTargets_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Add support for specifying linker flags in `.gorocket.yaml` configuration file
- Enable build-time optimizations like binary size reduction and variable injection
- Support both empty ldflags (no flags) and custom flags (e.g., "-s -w")

## Test plan
- [x] Add LdFlags field to BuildConfig model with YAML support
- [x] Update CommandProvider.BuildBinary to accept and apply ldflags parameter
- [x] Modify BuilderService to pass ldflags from config to build command
- [x] Update default config template with ldflags example
- [x] Regenerate mocks and update all tests for interface changes
- [x] Verify ldflags functionality with test build

🤖 Generated with [Claude Code](https://claude.ai/code)