### PR TITLE
feat: Add Go template support for configuration files

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -8,6 +8,7 @@ import (
 	providerMocks "github.com/koki-develop/gorocket/internal/providers/mocks"
 	serviceMocks "github.com/koki-develop/gorocket/internal/services/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestBuildCommand_FormulaGeneration(t *testing.T) {
@@ -81,8 +82,8 @@ func TestBuildCommand_FormulaGeneration(t *testing.T) {
 			}
 
 			mockConfigService.EXPECT().ConfigExists().Return(true)
-			mockConfigService.EXPECT().LoadConfig().Return(config, nil)
 			mockVersionService.EXPECT().GetBuildInfo().Return(buildInfo, nil)
+			mockConfigService.EXPECT().LoadConfig(mock.AnythingOfType("*models.TemplateData")).Return(config, nil)
 			mockFS.EXPECT().EnsureDistDir(false).Return(nil)
 			mockBuilderService.EXPECT().BuildTargets(buildInfo, config.Build).Return(buildResults, nil)
 			mockArchiverService.EXPECT().CreateArchives(buildInfo, buildResults).Return(archiveResults, nil)
@@ -161,8 +162,8 @@ func TestBuildCommand_FullWorkflow(t *testing.T) {
 
 	// Setup expectations in the order they should be called
 	mockConfigService.EXPECT().ConfigExists().Return(true)
-	mockConfigService.EXPECT().LoadConfig().Return(config, nil)
 	mockVersionService.EXPECT().GetBuildInfo().Return(buildInfo, nil)
+	mockConfigService.EXPECT().LoadConfig(mock.AnythingOfType("*models.TemplateData")).Return(config, nil)
 	mockFS.EXPECT().EnsureDistDir(true).Return(nil)
 	mockBuilderService.EXPECT().BuildTargets(buildInfo, config.Build).Return(buildResults, nil)
 	mockArchiverService.EXPECT().CreateArchives(buildInfo, buildResults).Return(archiveResults, nil)

--- a/internal/models/build_result.go
+++ b/internal/models/build_result.go
@@ -1,0 +1,13 @@
+package models
+
+// BuildCommandResult contains all data produced by a build command execution
+type BuildCommandResult struct {
+	// BuildInfo contains version and module information
+	BuildInfo *BuildInfo
+	// Config contains the processed configuration
+	Config *Config
+	// TemplateData contains the template variables used
+	TemplateData *TemplateData
+	// ArchiveResults contains information about created archives
+	ArchiveResults []ArchiveResult
+}

--- a/internal/models/template_data.go
+++ b/internal/models/template_data.go
@@ -1,0 +1,9 @@
+package models
+
+// TemplateData contains data available for template processing in configuration files
+type TemplateData struct {
+	// Version is the current git tag version (e.g., "v1.0.0")
+	Version string
+	// Module is the Go module name from go.mod
+	Module string
+}

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -1,0 +1,301 @@
+package providers
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/koki-develop/gorocket/internal/models"
+	"github.com/koki-develop/gorocket/internal/providers/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestConfigProvider_LoadConfig_WithTemplate(t *testing.T) {
+	tests := []struct {
+		name          string
+		configContent string
+		templateData  *models.TemplateData
+		expected      *models.Config
+		setupMocks    func(mockFS *mocks.MockFileSystemProvider)
+		expectedError string
+	}{
+		{
+			name: "successful template processing",
+			configContent: `build:
+  ldflags: "-X main.version={{.Version}} -X main.module={{.Module}}"
+  targets:
+    - os: linux
+      arch: [amd64, arm64]
+brew:
+  repository:
+    owner: "{{.Module}}"
+    name: "homebrew-tap"`,
+			templateData: &models.TemplateData{
+				Version: "v1.0.0",
+				Module:  "github.com/example/project",
+			},
+			expected: &models.Config{
+				Build: models.BuildConfig{
+					LdFlags: "-X main.version=v1.0.0 -X main.module=github.com/example/project",
+					Targets: []models.Target{
+						{
+							OS:   "linux",
+							Arch: []string{"amd64", "arm64"},
+						},
+					},
+				},
+				Brew: &models.BrewConfig{
+					Repository: models.Repository{
+						Owner: "github.com/example/project",
+						Name:  "homebrew-tap",
+					},
+				},
+			},
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				reader := io.NopCloser(strings.NewReader(`build:
+  ldflags: "-X main.version={{.Version}} -X main.module={{.Module}}"
+  targets:
+    - os: linux
+      arch: [amd64, arm64]
+brew:
+  repository:
+    owner: "{{.Module}}"
+    name: "homebrew-tap"`))
+				mockFS.EXPECT().Open(".gorocket.yml").Return(reader, nil)
+			},
+		},
+		{
+			name: "template parse error",
+			configContent: `build:
+  ldflags: "{{.InvalidSyntax}"`,
+			templateData: &models.TemplateData{
+				Version: "v1.0.0",
+			},
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				reader := io.NopCloser(strings.NewReader(`build:
+  ldflags: "{{.InvalidSyntax}"`))
+				mockFS.EXPECT().Open(".gorocket.yml").Return(reader, nil)
+			},
+			expectedError: "failed to parse config template",
+		},
+		{
+			name: "template variable does not exist",
+			configContent: `build:
+  ldflags: "{{.NonExistentField}}"`,
+			templateData: &models.TemplateData{
+				Version: "v1.0.0",
+			},
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				reader := io.NopCloser(strings.NewReader(`build:
+  ldflags: "{{.NonExistentField}}"`))
+				mockFS.EXPECT().Open(".gorocket.yml").Return(reader, nil)
+			},
+			expectedError: "failed to execute config template",
+		},
+		{
+			name: "invalid YAML after template processing",
+			configContent: `build:
+  ldflags: "{{.Version}}"
+  targets:
+    invalid yaml content`,
+			templateData: &models.TemplateData{
+				Version: "v1.0.0",
+			},
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				reader := io.NopCloser(strings.NewReader(`build:
+  ldflags: "{{.Version}}"
+  targets:
+    invalid yaml content`))
+				mockFS.EXPECT().Open(".gorocket.yml").Return(reader, nil)
+			},
+			expectedError: "failed to decode config YAML",
+		},
+		{
+			name:         "file open error",
+			templateData: &models.TemplateData{},
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Open(".gorocket.yml").Return(nil, errors.New("file not found"))
+			},
+			expectedError: "file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := mocks.NewMockFileSystemProvider(t)
+			tt.setupMocks(mockFS)
+
+			provider := NewConfigProvider(mockFS)
+			result, err := provider.LoadConfig(tt.templateData)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				if tt.expected != nil {
+					assert.Equal(t, tt.expected, result)
+				}
+			}
+
+			mockFS.AssertExpectations(t)
+		})
+	}
+}
+
+func TestConfigProvider_LoadConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(mockFS *mocks.MockFileSystemProvider)
+		expected      *models.Config
+		expectedError string
+	}{
+		{
+			name: "successful config load",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				configYAML := `build:
+  targets:
+    - os: linux
+      arch: [amd64]`
+				reader := io.NopCloser(strings.NewReader(configYAML))
+				mockFS.EXPECT().Open(".gorocket.yml").Return(reader, nil)
+			},
+			expected: &models.Config{
+				Build: models.BuildConfig{
+					Targets: []models.Target{
+						{
+							OS:   "linux",
+							Arch: []string{"amd64"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "file open error",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Open(".gorocket.yml").Return(nil, errors.New("file not found"))
+			},
+			expectedError: "file not found",
+		},
+		{
+			name: "invalid YAML",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				invalidYAML := `build:
+  targets:
+    invalid yaml`
+				reader := io.NopCloser(strings.NewReader(invalidYAML))
+				mockFS.EXPECT().Open(".gorocket.yml").Return(reader, nil)
+			},
+			expectedError: "yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := mocks.NewMockFileSystemProvider(t)
+			tt.setupMocks(mockFS)
+
+			provider := NewConfigProvider(mockFS)
+			result, err := provider.LoadConfig(nil)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+
+			mockFS.AssertExpectations(t)
+		})
+	}
+}
+
+func TestConfigProvider_ConfigExists(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupMocks func(mockFS *mocks.MockFileSystemProvider)
+		expected   bool
+	}{
+		{
+			name: "config exists",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Stat(".gorocket.yml").Return(nil, nil)
+			},
+			expected: true,
+		},
+		{
+			name: "config does not exist",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Stat(".gorocket.yml").Return(nil, errors.New("file not found"))
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := mocks.NewMockFileSystemProvider(t)
+			tt.setupMocks(mockFS)
+
+			provider := NewConfigProvider(mockFS)
+			result := provider.ConfigExists()
+
+			assert.Equal(t, tt.expected, result)
+			mockFS.AssertExpectations(t)
+		})
+	}
+}
+
+func TestConfigProvider_CreateDefaultConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(mockFS *mocks.MockFileSystemProvider)
+		expectedError string
+	}{
+		{
+			name: "successful creation",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Stat(".gorocket.yml").Return(nil, errors.New("not found"))
+				mockFS.EXPECT().WriteFile(".gorocket.yml", mock.Anything, mock.Anything).Return(nil)
+			},
+		},
+		{
+			name: "config already exists",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Stat(".gorocket.yml").Return(nil, nil)
+			},
+			expectedError: ".gorocket.yml already exists",
+		},
+		{
+			name: "write error",
+			setupMocks: func(mockFS *mocks.MockFileSystemProvider) {
+				mockFS.EXPECT().Stat(".gorocket.yml").Return(nil, errors.New("not found"))
+				mockFS.EXPECT().WriteFile(".gorocket.yml", mock.Anything, mock.Anything).Return(errors.New("permission denied"))
+			},
+			expectedError: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := mocks.NewMockFileSystemProvider(t)
+			tt.setupMocks(mockFS)
+
+			provider := NewConfigProvider(mockFS)
+			err := provider.CreateDefaultConfig()
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockFS.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/providers/mocks/mock_ConfigProvider.go
+++ b/internal/providers/mocks/mock_ConfigProvider.go
@@ -171,8 +171,8 @@ func (_c *MockConfigProvider_GetDefaultConfigData_Call) RunAndReturn(run func() 
 }
 
 // LoadConfig provides a mock function for the type MockConfigProvider
-func (_mock *MockConfigProvider) LoadConfig() (*models.Config, error) {
-	ret := _mock.Called()
+func (_mock *MockConfigProvider) LoadConfig(templateData *models.TemplateData) (*models.Config, error) {
+	ret := _mock.Called(templateData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LoadConfig")
@@ -180,18 +180,18 @@ func (_mock *MockConfigProvider) LoadConfig() (*models.Config, error) {
 
 	var r0 *models.Config
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (*models.Config, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(*models.TemplateData) (*models.Config, error)); ok {
+		return returnFunc(templateData)
 	}
-	if returnFunc, ok := ret.Get(0).(func() *models.Config); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(*models.TemplateData) *models.Config); ok {
+		r0 = returnFunc(templateData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Config)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(*models.TemplateData) error); ok {
+		r1 = returnFunc(templateData)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -204,13 +204,20 @@ type MockConfigProvider_LoadConfig_Call struct {
 }
 
 // LoadConfig is a helper method to define mock.On call
-func (_e *MockConfigProvider_Expecter) LoadConfig() *MockConfigProvider_LoadConfig_Call {
-	return &MockConfigProvider_LoadConfig_Call{Call: _e.mock.On("LoadConfig")}
+//   - templateData *models.TemplateData
+func (_e *MockConfigProvider_Expecter) LoadConfig(templateData interface{}) *MockConfigProvider_LoadConfig_Call {
+	return &MockConfigProvider_LoadConfig_Call{Call: _e.mock.On("LoadConfig", templateData)}
 }
 
-func (_c *MockConfigProvider_LoadConfig_Call) Run(run func()) *MockConfigProvider_LoadConfig_Call {
+func (_c *MockConfigProvider_LoadConfig_Call) Run(run func(templateData *models.TemplateData)) *MockConfigProvider_LoadConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 *models.TemplateData
+		if args[0] != nil {
+			arg0 = args[0].(*models.TemplateData)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -220,7 +227,7 @@ func (_c *MockConfigProvider_LoadConfig_Call) Return(config *models.Config, err 
 	return _c
 }
 
-func (_c *MockConfigProvider_LoadConfig_Call) RunAndReturn(run func() (*models.Config, error)) *MockConfigProvider_LoadConfig_Call {
+func (_c *MockConfigProvider_LoadConfig_Call) RunAndReturn(run func(templateData *models.TemplateData) (*models.Config, error)) *MockConfigProvider_LoadConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -8,7 +8,7 @@ import (
 type ConfigService interface {
 	ConfigExists() bool
 	CreateDefaultConfig() error
-	LoadConfig() (*models.Config, error)
+	LoadConfig(templateData *models.TemplateData) (*models.Config, error)
 	GetDefaultConfigData() []byte
 }
 
@@ -30,10 +30,11 @@ func (c *configService) CreateDefaultConfig() error {
 	return c.configProvider.CreateDefaultConfig()
 }
 
-func (c *configService) LoadConfig() (*models.Config, error) {
-	return c.configProvider.LoadConfig()
+func (c *configService) LoadConfig(templateData *models.TemplateData) (*models.Config, error) {
+	return c.configProvider.LoadConfig(templateData)
 }
 
 func (c *configService) GetDefaultConfigData() []byte {
 	return c.configProvider.GetDefaultConfigData()
 }
+

--- a/internal/services/mocks/mock_ConfigService.go
+++ b/internal/services/mocks/mock_ConfigService.go
@@ -171,8 +171,8 @@ func (_c *MockConfigService_GetDefaultConfigData_Call) RunAndReturn(run func() [
 }
 
 // LoadConfig provides a mock function for the type MockConfigService
-func (_mock *MockConfigService) LoadConfig() (*models.Config, error) {
-	ret := _mock.Called()
+func (_mock *MockConfigService) LoadConfig(templateData *models.TemplateData) (*models.Config, error) {
+	ret := _mock.Called(templateData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LoadConfig")
@@ -180,18 +180,18 @@ func (_mock *MockConfigService) LoadConfig() (*models.Config, error) {
 
 	var r0 *models.Config
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (*models.Config, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(*models.TemplateData) (*models.Config, error)); ok {
+		return returnFunc(templateData)
 	}
-	if returnFunc, ok := ret.Get(0).(func() *models.Config); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(*models.TemplateData) *models.Config); ok {
+		r0 = returnFunc(templateData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Config)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(*models.TemplateData) error); ok {
+		r1 = returnFunc(templateData)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -204,13 +204,20 @@ type MockConfigService_LoadConfig_Call struct {
 }
 
 // LoadConfig is a helper method to define mock.On call
-func (_e *MockConfigService_Expecter) LoadConfig() *MockConfigService_LoadConfig_Call {
-	return &MockConfigService_LoadConfig_Call{Call: _e.mock.On("LoadConfig")}
+//   - templateData *models.TemplateData
+func (_e *MockConfigService_Expecter) LoadConfig(templateData interface{}) *MockConfigService_LoadConfig_Call {
+	return &MockConfigService_LoadConfig_Call{Call: _e.mock.On("LoadConfig", templateData)}
 }
 
-func (_c *MockConfigService_LoadConfig_Call) Run(run func()) *MockConfigService_LoadConfig_Call {
+func (_c *MockConfigService_LoadConfig_Call) Run(run func(templateData *models.TemplateData)) *MockConfigService_LoadConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 *models.TemplateData
+		if args[0] != nil {
+			arg0 = args[0].(*models.TemplateData)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -220,7 +227,7 @@ func (_c *MockConfigService_LoadConfig_Call) Return(config *models.Config, err e
 	return _c
 }
 
-func (_c *MockConfigService_LoadConfig_Call) RunAndReturn(run func() (*models.Config, error)) *MockConfigService_LoadConfig_Call {
+func (_c *MockConfigService_LoadConfig_Call) RunAndReturn(run func(templateData *models.TemplateData) (*models.Config, error)) *MockConfigService_LoadConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Add Go template support to .gorocket.yml configuration files
- Enable dynamic variable substitution using {{.Version}} and {{.Module}}
- Consolidate build result data with new BuildCommandResult struct
- Simplify configuration loading by removing unnecessary nil checks

## Changes
### Core Features
- **TemplateData model**: New struct containing Version and Module fields for template processing
- **Enhanced LoadConfig**: Extended to process Go template syntax before YAML parsing
- **BuildCommandResult**: New consolidated struct for build command output data
- **Simplified config processing**: Removed unnecessary nil checks and streamlined template handling

### Template Variables
- `{{.Version}}`: Current git tag version (e.g., "v1.0.0")  
- `{{.Module}}`: Go module name from go.mod

### Usage Examples
```yaml
build:
  ldflags: "-X main.version={{.Version}} -X main.module={{.Module}}"
  targets:
    - os: linux
      arch: [amd64, arm64]

brew:
  repository:
    owner: "{{.Module}}"
    name: "homebrew-tap"
```

### Code Quality
- Added comprehensive test coverage for template functionality
- Updated existing tests to work with new LoadConfig signature
- Regenerated mocks to reflect interface changes
- Maintained backward compatibility through optional template data parameter

## Test plan
- [x] All existing tests pass
- [x] New template processing tests added
- [x] Both build and release commands work with template variables
- [x] Error handling for invalid template syntax
- [x] Fallback behavior when template data is not provided

🤖 Generated with [Claude Code](https://claude.ai/code)